### PR TITLE
document the rename dance for safe db updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ sub vcl_recv {
 
 More examples available at https://github.com/fgsch/libvmod-geoip2/wiki.
 
+## Caveat
+
+As the GeoIP2 file is mmaped into the varnish process by libmaxminddb,
+truncating/overwriting it (ie. via wget) under load can cause the
+varnish worker process to segfault.
+
+It is therefore recommended to download the update as a new file, and
+then ``mv`` the new file onto the old active database, before reloading
+the vcl.
+
 ## License
 
 This VMOD is licensed under BSD license. See LICENSE for details.


### PR DESCRIPTION
Somewhat easily testable. Generate load on your geoip2-using varnish server, run truncate your-fine-file.mmdb -s 0

Crashes with something similar to:

Backtrace:
  0x433e61: pan_ic+0x191
  0x454283: varnishd() [0x454283]
  0x7fdfd96ee390: libpthread.so.0(+0x11390) [0x7fdfd96ee390]
  0x7fdfcb479060: libmaxminddb.so.0(+0x1060) [0x7fdfcb479060]
  0x7fdfcb47a1a4: libmaxminddb.so.0(MMDB_lookup_sockaddr+0x1b4) [0x7fdfcb47a1a4]
  0x7fdfcb67f0ce: libvmod_geoip2.so(vmod_geoip2_lookup+0x8e) [0x7fdfcb67f0ce]
  0x7fdfc910ddab: vgc.so(VGC_function_geoblock+0x17b) [0x7fdfc910ddab]
  0x7fdfc910f7d9: vgc.so(VGC_function_vcl_recv+0x119) [0x7fdfc910f7d9]
  0x44004c: vcl_call_method+0x1fc
  0x4423ca: VCL_recv_method+0x5a
